### PR TITLE
allow missing ego from codebook

### DIFF
--- a/src/ducks/modules/mock.js
+++ b/src/ducks/modules/mock.js
@@ -68,8 +68,8 @@ const makeEntity = (typeID, variables = {}, promptAttributes = {}) => {
 };
 
 const makeNetwork = (protocol) => {
-  const codebookNodeTypes = Object.keys(protocol.codebook.node);
-  const codebookEdgeTypes = Object.keys(protocol.codebook.edge);
+  const codebookNodeTypes = Object.keys(protocol.codebook.node || {});
+  const codebookEdgeTypes = Object.keys(protocol.codebook.edge || {});
 
   // Generate nodes
   const nodes = [];
@@ -86,7 +86,7 @@ const makeNetwork = (protocol) => {
       )));
   });
 
-  const ego = makeEntity(null, protocol.codebook.ego.variables);
+  const ego = makeEntity(null, (protocol.codebook.ego || {}).variables);
 
   const edges = [];
   const networkMaxEdges = 20;

--- a/src/ducks/modules/sessions.js
+++ b/src/ducks/modules/sessions.js
@@ -249,7 +249,7 @@ const updateEgo = (modelData = {}, attributeData = {}) => (dispatch, getState) =
   const { activeSessionId, sessions, installedProtocols } = getState();
 
   const activeProtocol = installedProtocols[sessions[activeSessionId].protocolUID];
-  const egoRegistry = activeProtocol.codebook.ego;
+  const egoRegistry = activeProtocol.codebook.ego || {};
 
   dispatch({
     type: networkActionTypes.UPDATE_EGO,
@@ -327,7 +327,7 @@ const addSession = (caseId, protocolUID, sessionNetwork) => (dispatch, getState)
 
   const { installedProtocols } = getState();
   const activeProtocol = installedProtocols[protocolUID];
-  const egoRegistry = activeProtocol.codebook.ego;
+  const egoRegistry = activeProtocol.codebook.ego || {};
   const egoAttributeData = getDefaultAttributesForEntityType(egoRegistry.variables);
 
   dispatch({


### PR DESCRIPTION
A protocol without an ego entry would load in NC, but not allow a new session to be started. This fixes that, and also makes sure protocols missing ego/nodes/edges in their codebooks can still create mock sessions.

To test, create a protocol without any ego stages, add to NC as a protocol, and click "start new interview".