### PR TITLE
make sure beforeNext runs on enter pressed

### DIFF
--- a/src/containers/ProtocolScreen.js
+++ b/src/containers/ProtocolScreen.js
@@ -36,8 +36,8 @@ class Protocol extends Component {
     this.beforeNext = {};
   }
 
-  onComplete = () => {
-    const pendingDirection = this.state.pendingDirection;
+  onComplete = (directionOverride) => {
+    const pendingDirection = directionOverride || this.state.pendingDirection;
     const pendingStage = this.state.pendingStage;
 
     const navigate = (pendingStage === -1) ?

--- a/src/containers/SlidesForm/SlideFormEdge.js
+++ b/src/containers/SlidesForm/SlideFormEdge.js
@@ -23,6 +23,7 @@ class SlideFormEdge extends PureComponent {
       toNode,
       subject,
       initialValues,
+      submitButton,
     } = this.props;
 
     return (
@@ -40,6 +41,7 @@ class SlideFormEdge extends PureComponent {
                 autoFocus={false}
                 subject={subject}
                 onSubmit={this.handleSubmit}
+                submitButton={submitButton}
               />
             </Scroller>
           </div>
@@ -54,6 +56,11 @@ SlideFormEdge.propTypes = {
   onUpdate: PropTypes.func.isRequired,
   subject: PropTypes.object.isRequired,
   item: PropTypes.object.isRequired,
+  submitButton: PropTypes.object,
+};
+
+SlideFormEdge.defaultProps = {
+  submitButton: <button type="submit" key="submit" aria-label="Submit" hidden />,
 };
 
 const withEdgeProps = withProps(({ item }) => ({

--- a/src/containers/SlidesForm/SlideFormNode.js
+++ b/src/containers/SlidesForm/SlideFormNode.js
@@ -19,6 +19,7 @@ class SlideFormNode extends PureComponent {
       item,
       initialValues,
       subject,
+      submitButton,
     } = this.props;
 
     return (
@@ -34,6 +35,7 @@ class SlideFormNode extends PureComponent {
                 autoFocus={false}
                 subject={subject}
                 onSubmit={this.handleSubmit}
+                submitButton={submitButton}
               />
             </Scroller>
           </div>
@@ -48,11 +50,13 @@ SlideFormNode.propTypes = {
   subject: PropTypes.object.isRequired,
   item: PropTypes.object.isRequired,
   onUpdate: PropTypes.func,
+  submitButton: PropTypes.object,
 };
 
 SlideFormNode.defaultProps = {
   form: {},
   onUpdate: () => {},
+  submitButton: <button type="submit" key="submit" aria-label="Submit" hidden />,
 };
 
 const withNodeProps = withProps(({ item }) => ({

--- a/src/containers/SlidesForm/SlidesForm.js
+++ b/src/containers/SlidesForm/SlidesForm.js
@@ -64,7 +64,7 @@ const SlidesForm = (props) => {
     swiper.slideNext();
   };
 
-  const isLastItem = () => activeIndex === items.length;
+  const isLastItem = () => activeIndex >= items.length;
 
   const submitForm = () => {
     submitFormRedux(getFormName(getItemIndex()));
@@ -111,7 +111,7 @@ const SlidesForm = (props) => {
         confirmIfChanged()
           .then((confirmed) => {
             if (confirmed) {
-              onComplete(); // show next stage and lose changes
+              onComplete(direction); // show next stage and lose changes
               return;
             }
             submitForm(); // submit so errors will display
@@ -123,7 +123,7 @@ const SlidesForm = (props) => {
     setPendingStage(index);
     // Determine if we should leave the stage.
     if (shouldContinue(direction)) {
-      onComplete();
+      onComplete(direction);
       return;
     }
 
@@ -174,7 +174,7 @@ const SlidesForm = (props) => {
     updateItem(...update);
 
     if (isComplete(pendingDirection, pendingStage)) {
-      onComplete();
+      onComplete(pendingDirection);
       return;
     }
 
@@ -189,6 +189,12 @@ const SlidesForm = (props) => {
   useEffect(() => {
     registerBeforeNext(beforeNext);
   }, [swiper, beforeNext]);
+
+  // enter key should always move forward, and needs to process using beforeNext
+  const handleEnterSubmit = (e) => {
+    beforeNext(1);
+    e.preventDefault();
+  };
 
   return (
     <div className={parentClasses}>
@@ -218,6 +224,7 @@ const SlidesForm = (props) => {
               item={item}
               onUpdate={handleUpdate}
               form={slideForm}
+              submitButton={<button type="submit" key="submit" aria-label="Submit" hidden onClick={handleEnterSubmit} />}
             />
           );
         })}

--- a/src/containers/SlidesForm/__tests__/__snapshots__/SlideFormEdge.test.js.snap
+++ b/src/containers/SlidesForm/__tests__/__snapshots__/SlideFormEdge.test.js.snap
@@ -28,5 +28,12 @@ exports[`<SlideFormEdge /> should render 1`] = `
     }
   }
   stageIndex={1}
+  submitButton={
+    <button
+      aria-label="Submit"
+      hidden={true}
+      type="submit"
+    />
+  }
 />
 `;

--- a/src/containers/SlidesForm/__tests__/__snapshots__/SlideFormNode.test.js.snap
+++ b/src/containers/SlidesForm/__tests__/__snapshots__/SlideFormNode.test.js.snap
@@ -24,5 +24,12 @@ exports[`<SlideFormNode /> should render 1`] = `
   nodeIndex={1}
   onUpdate={[Function]}
   stageIndex={1}
+  submitButton={
+    <button
+      aria-label="Submit"
+      hidden={true}
+      type="submit"
+    />
+  }
 />
 `;


### PR DESCRIPTION
Resolves #1025.

Steps to reproduce the issue:
0. create a protocol with a name generator and an alter form that has a text field.
1. add protocol and start a new interview in NC.
2. add a node.
3. navigate to the alter form.
4. Click next arrow to get past the intro to first node on the alter form.
5. Mouse in to the text box and hit enter on the keyboard. Will not move to the next stage and says "2 of 1" at the bottom progress bar.

Basically, pressing the enter key in a form uses the redux hidden submit button to submit the form, bypassing all of our `beforeNext()` logic. The `beforeNext()` logic checks to make sure it's okay to submit a form, and whether we move to the next stage or simply the next node in the current stage. So this makes sure that logic actually still happens before submitting for both Alter and Alter edge form.